### PR TITLE
test: Fix unit test and add toolchain spec

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,6 @@
+[toolchain]
+channel = "1.77"
+components = ["clippy", "rust-src", "rustfmt"]
+targets = [
+    "thumbv7em-none-eabihf",
+]

--- a/tests/command_complete.rs
+++ b/tests/command_complete.rs
@@ -2,7 +2,7 @@ extern crate stm32wb_hci as hci;
 
 use hci::event::command::*;
 use hci::event::*;
-use hci::vendor::event::command::VendorReturnParameters;
+use hci::vendor::event::response::VendorReturnParameters;
 use std::convert::TryFrom;
 
 #[derive(Debug)]


### PR DESCRIPTION
I've had to explicitly disable the `defmt` feature when running unit tests. There's a compilation error if you try to compile with that feature enabled (presumably something about `defmt` on x86?). Probably would be a good idea to add `cfg` guards to check for x86 or test or something like that, so that tests can be executed no matter what feature set is enabled, but I'll let someone else deal with that (or not).