### PR TITLE
Use correct buffer size for controller read

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "stm32wb-hci"
-version = "0.1702.0"
+version = "0.1703.0"
 authors = [
     "Daniel Gallagher <pdanielgallagher@gmail.com>",
     "Ghaith Oueslati <ghaith.oueslati@enis.tn>",

--- a/src/host/uart.rs
+++ b/src/host/uart.rs
@@ -88,7 +88,7 @@ where
         const EVENT_PACKET_HEADER_LENGTH: usize = 3;
         const PARAM_LEN_BYTE: usize = 2;
 
-        let mut packet = [0u8; MAX_EVENT_LENGTH];
+        let mut packet = [0u8; MAX_EVENT_LENGTH + EVENT_PACKET_HEADER_LENGTH];
         self.controller_read_into(&mut packet).await;
 
         let packet_type = packet[0];


### PR DESCRIPTION
The buffer passed to `controller_read_into` has to have enough space for payload + event header.