### PR TITLE
correct parsing of notification completion event

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "stm32wb-hci"
-version = "0.1703.0"
+version = "0.1703.1"
 authors = [
     "Daniel Gallagher <pdanielgallagher@gmail.com>",
     "Ghaith Oueslati <ghaith.oueslati@enis.tn>",

--- a/src/vendor/event/mod.rs
+++ b/src/vendor/event/mod.rs
@@ -821,8 +821,8 @@ impl VendorEvent {
                 to_gatt_multi_notification(buffer)?,
             )),
             0x0C1B => Ok(VendorEvent::GattNotificationComplete({
-                require_len!(buffer, 2);
-                AttributeHandle(LittleEndian::read_u16(buffer))
+                require_len!(buffer, 4);
+                AttributeHandle(LittleEndian::read_u16(&buffer[2..]))
             })),
             0x0C1D => Ok(VendorEvent::GattReadExt(to_gatt_read_ext(buffer)?)),
             0x0C1E => Ok(VendorEvent::GattIndicationExt(to_attribute_value_ext(


### PR DESCRIPTION
Real easy one. The buffer for the notification complete event was not being parsed properly. It is two u16s, the first being the opcode, the second being the attribute handle.