### PR TITLE
Feat: [SW-522] windows bluetooth

### DIFF
--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -849,11 +849,12 @@ impl TryFrom<u8> for ConnectionRole {
 
 /// Values for the central (master) clock accuracy as returned by the
 /// [LE Connection Complete](Event::LeConnectionComplete) event.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum CentralClockAccuracy {
     /// The central clock is accurate to at least 500 parts-per-million.  This value is also used
     /// when the device is a central device.
+    #[default]
     Ppm500,
     /// The central clock is accurate to at least 250 parts-per-million.
     Ppm250,
@@ -890,17 +891,35 @@ impl TryFrom<u8> for CentralClockAccuracy {
 
 fn to_le_connection_complete(payload: &[u8]) -> Result<LeConnectionComplete, Error> {
     require_len!(payload, 19);
+    // For direct connect advertisements a connection complete event is generated when a connection timeout or success occurs.
+    // This event does not contain the conn_interval or the central_clock_accuracy, so we need to use defaults in that case.
     let mut bd_addr = crate::BdAddr([0; 6]);
     bd_addr.0.copy_from_slice(&payload[6..12]);
+
+    let conn_interval = if payload[12..18].iter().all(|&x| x == 0) {
+        // Direct connect
+        FixedConnectionInterval::default()
+    } else {
+        FixedConnectionInterval::from_bytes(&payload[12..18])
+        .map_err(Error::BadConnectionInterval)?
+    };
+
+
+    let central_clock_accuracy = if payload[18] == 0 {
+        // Direct connect
+        CentralClockAccuracy::default()
+    } else {
+        payload[18].try_into()?
+    };
+
     Ok(LeConnectionComplete {
         status: payload[1].try_into().map_err(rewrap_bad_status)?,
         conn_handle: ConnectionHandle(LittleEndian::read_u16(&payload[2..])),
         role: payload[4].try_into()?,
         peer_bd_addr: crate::to_bd_addr_type(payload[5], bd_addr)
             .map_err(rewrap_bd_addr_type_err)?,
-        conn_interval: FixedConnectionInterval::from_bytes(&payload[12..18])
-            .map_err(Error::BadConnectionInterval)?,
-        central_clock_accuracy: payload[18].try_into()?,
+        conn_interval, 
+        central_clock_accuracy,
     })
 }
 

--- a/src/types/connection_interval.rs
+++ b/src/types/connection_interval.rs
@@ -292,6 +292,16 @@ pub struct FixedConnectionInterval {
     supervision_timeout_: Duration,
 }
 
+impl Default for FixedConnectionInterval {
+    fn default() -> Self {
+        Self {
+            interval_: Duration::from_millis(10),
+            conn_latency_: 0,
+            supervision_timeout_: Duration::from_millis(10),
+        }
+    }
+}
+
 impl FixedConnectionInterval {
     /// Deserializes the connection interval from the given byte buffer.
     ///

--- a/src/vendor/command/gap.rs
+++ b/src/vendor/command/gap.rs
@@ -1617,8 +1617,8 @@ impl DirectConnectableParameters {
     const LENGTH: usize = 13;
 
     fn validate(&self) -> Result<(), Error> {
-        const MIN_DURATION: Duration = Duration::from_millis(20);
-        const MAX_DURATION: Duration = Duration::from_millis(10240);
+        const MIN_DURATION: Duration = Duration::from_micros(3750);
+        const MAX_DURATION: Duration = Duration::from_millis(1280);
 
         match self.advertising_type {
             AdvertisingType::ConnectableDirectedHighDutyCycle

--- a/src/vendor/command/l2cap.rs
+++ b/src/vendor/command/l2cap.rs
@@ -449,6 +449,6 @@ impl<'a> L2CapCocTxData<'a> {
 
         bytes[0] = self.channel_index;
         LittleEndian::write_u16(&mut bytes[1..], self.length);
-        bytes[3..3+self.data.len()].copy_from_slice(&self.data);
+        bytes[3..3+self.data.len()].copy_from_slice(self.data);
     }
 }

--- a/src/vendor/event/mod.rs
+++ b/src/vendor/event/mod.rs
@@ -962,7 +962,7 @@ fn to_l2cap_connection_update_accepted_result(
         _ => Err(VendorError::BadL2CapConnectionResponseResult(value)),
     }
 }
-
+#[allow(unused)]
 fn extract_l2cap_connection_update_response_result(
     buffer: &[u8],
 ) -> Result<L2CapConnectionUpdateResult, VendorError> {

--- a/src/vendor/event/response.rs
+++ b/src/vendor/event/response.rs
@@ -906,6 +906,17 @@ pub struct GapBondedDevices {
     address_buffer: [crate::BdAddrType; MAX_ADDRESSES],
 }
 
+impl Default for GapBondedDevices {
+    fn default() -> Self {
+        Self {
+            status: crate::Status::Success,
+            address_count: 0,
+            address_buffer: [crate::BdAddrType::Public(crate::BdAddr([0, 0, 0, 0, 0, 0]));
+                MAX_ADDRESSES],
+        }
+    }
+}
+
 // Max packet size (255 bytes) less non-address data (4 bytes) divided by peer address size (7):
 const MAX_ADDRESSES: usize = 35;
 

--- a/tests/event.rs
+++ b/tests/event.rs
@@ -276,10 +276,32 @@ fn le_connection_complete() {
 }
 
 #[test]
+fn le_connection_complete_direct() {
+    let buffer = [
+        0x3E, 19, 0x01, 0x00, 0x01, 0x02, 0x00, 0x00, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x0,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ];
+    match TestEvent::new(Packet(&buffer)) {
+        Ok(Event::LeConnectionComplete(event)) => {
+            assert_eq!(event.status, hci::Status::Success);
+            assert_eq!(event.conn_handle, hci::ConnectionHandle(0x0201));
+            assert_eq!(event.role, ConnectionRole::Central);
+            assert_eq!(
+                event.peer_bd_addr,
+                hci::BdAddrType::Public(hci::BdAddr([0x03, 0x04, 0x05, 0x06, 0x07, 0x08]))
+            );
+
+            assert_eq!(event.central_clock_accuracy, CentralClockAccuracy::Ppm500);
+        }
+        other => panic!("Did not get LE connection complete: {:?}", other),
+    }
+}
+
+#[test]
 fn le_connection_complete_failed_bad_role() {
     let buffer = [
         0x3E, 19, 0x01, 0x00, 0x01, 0x02, 0x02, 0x00, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
-        0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x00,
+        0x00, 0x0B, 0x00, 0x0D, 0x0A, 0x00,
     ];
     match TestEvent::new(Packet(&buffer)) {
         Err(Error::BadLeConnectionRole(code)) => assert_eq!(code, 0x02),
@@ -291,7 +313,7 @@ fn le_connection_complete_failed_bad_role() {
 fn le_connection_complete_failed_bad_address_type() {
     let buffer = [
         0x3E, 19, 0x01, 0x00, 0x01, 0x02, 0x00, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
-        0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x00,
+        0x00, 0x0B, 0x00, 0x0D, 0x0A, 0x00,
     ];
     match TestEvent::new(Packet(&buffer)) {
         Err(Error::BadLeAddressType(code)) => assert_eq!(code, 0x02),


### PR DESCRIPTION
Modify the current code to support the ADV_DIRECT_IND advertisement type.  The cpu2 will generate a connection complete event when the advertisement is complete and this event does not contain connection interval or clock accuracy, so we check for 0 and use a default